### PR TITLE
fix: fix diskcache fallback error handling

### DIFF
--- a/diskcache/get.go
+++ b/diskcache/get.go
@@ -110,9 +110,10 @@ retry:
 	if err = fn(databuf); err != nil {
 		// seek back
 		if !c.noFallbackOnError {
-			if _, err = c.rfd.Seek(-int64(dataHeaderLen+nbytes), io.SeekCurrent); err != nil {
-				return err
+			if _, serr := c.rfd.Seek(-int64(dataHeaderLen+nbytes), io.SeekCurrent); serr != nil {
+				return serr
 			}
+			seekBackVec.WithLabelValues(c.path).Inc()
 			goto __end // do not update .pos
 		}
 	}

--- a/diskcache/get.go
+++ b/diskcache/get.go
@@ -113,6 +113,7 @@ retry:
 			if _, serr := c.rfd.Seek(-int64(dataHeaderLen+nbytes), io.SeekCurrent); serr != nil {
 				return serr
 			}
+
 			seekBackVec.WithLabelValues(c.path).Inc()
 			goto __end // do not update .pos
 		}
@@ -122,8 +123,8 @@ __updatePos:
 	// update seek position
 	if !c.noPos {
 		c.pos.Seek += int64(dataHeaderLen + nbytes)
-		if err = c.pos.dumpFile(); err != nil {
-			return err
+		if derr := c.pos.dumpFile(); derr != nil {
+			return derr
 		}
 	}
 

--- a/diskcache/get_test.go
+++ b/diskcache/get_test.go
@@ -31,16 +31,18 @@ func TestFallbackOnError(t *T.T) {
 
 		assert.NoError(t, c.rotate())
 
-		c.Get(func(_ []byte) error { //nolint: errcheck
+		// should get error when callback fail
+		require.Error(t, c.Get(func(_ []byte) error {
 			return fmt.Errorf("get error")
-		})
+		}))
 
 		assert.Equal(t, int64(0), c.pos.Seek)
 
-		c.Get(func(x []byte) error { // nolint:errcheck
+		// should no error when callback ok
+		assert.NoError(t, c.Get(func(x []byte) error {
 			assert.Equal(t, data, x)
 			return nil
-		})
+		}))
 
 		reg := prometheus.NewRegistry()
 		register(reg)

--- a/diskcache/get_test.go
+++ b/diskcache/get_test.go
@@ -19,7 +19,6 @@ import (
 
 func TestFallbackOnError(t *T.T) {
 	t.Run(`fallback-on-error`, func(t *T.T) {
-
 		ResetMetrics()
 
 		p := t.TempDir()

--- a/diskcache/metric.go
+++ b/diskcache/metric.go
@@ -19,6 +19,7 @@ var (
 	getVec,
 	putBytesVec,
 	wakeupVec,
+	seekBackVec,
 	getBytesVec *prometheus.CounterVec
 
 	sizeVec,
@@ -126,6 +127,15 @@ func setupMetrics() {
 		[]string{"path"},
 	)
 
+	seekBackVec = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: ns,
+			Name:      "seek_back",
+			Help:      "Seek back when Get() got any error",
+		},
+		[]string{"path"},
+	)
+
 	getBytesVec = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
@@ -213,6 +223,7 @@ func setupMetrics() {
 		getVec,
 		putBytesVec,
 		wakeupVec,
+		seekBackVec,
 		getBytesVec,
 
 		openTimeVec,
@@ -237,6 +248,7 @@ func register(reg *prometheus.Registry) {
 		getVec,
 		putBytesVec,
 		wakeupVec,
+		seekBackVec,
 		getBytesVec,
 
 		capVec,
@@ -258,6 +270,7 @@ func ResetMetrics() {
 	getVec.Reset()
 	putBytesVec.Reset()
 	wakeupVec.Reset()
+	seekBackVec.Reset()
 	getBytesVec.Reset()
 	capVec.Reset()
 	batchSizeVec.Reset()
@@ -283,6 +296,7 @@ func Metrics() []prometheus.Collector {
 		getVec,
 		putBytesVec,
 		wakeupVec,
+		seekBackVec,
 		getBytesVec,
 
 		sizeVec,

--- a/diskcache/metric.go
+++ b/diskcache/metric.go
@@ -130,7 +130,7 @@ func setupMetrics() {
 	seekBackVec = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: ns,
-			Name:      "seek_back",
+			Name:      "seek_back_total",
 			Help:      "Seek back when Get() got any error",
 		},
 		[]string{"path"},

--- a/point/sort.go
+++ b/point/sort.go
@@ -13,6 +13,7 @@ import (
 func SortByTime(pts []*Point) {
 	slices.SortFunc(pts, func(l, r *Point) int {
 		diff := l.Time().Sub(r.Time())
+		// nolint: gocritic
 		if diff == 0 {
 			return 0
 		} else if diff > 0 {


### PR DESCRIPTION
Add metric on `Get()` error.

When `Get()` error, a fallback read(seek back to 1 record position) is set, and we export a metric to detect that.