### PR TITLE
refact(point): refact point decode

### DIFF
--- a/point/decode_test.go
+++ b/point/decode_test.go
@@ -506,7 +506,7 @@ func BenchmarkDecode(b *T.B) {
 	r := NewRander(WithFixedTags(true), WithRandText(3))
 	pts := r.Rand(1000)
 
-	b.Run("bench-decode-lp", func(b *T.B) {
+	b.Run("decode-lp", func(b *T.B) {
 		enc := GetEncoder()
 		defer PutEncoder(enc)
 
@@ -521,7 +521,7 @@ func BenchmarkDecode(b *T.B) {
 		}
 	})
 
-	b.Run("bench-decode-pb", func(b *T.B) {
+	b.Run("decode-pb", func(b *T.B) {
 		enc := GetEncoder(WithEncEncoding(Protobuf))
 		defer PutEncoder(enc)
 
@@ -536,7 +536,52 @@ func BenchmarkDecode(b *T.B) {
 		}
 	})
 
-	b.Run("bench-decode-json", func(b *T.B) {
+	b.Run("decode-pb-no-check", func(b *T.B) {
+		enc := GetEncoder(WithEncEncoding(Protobuf))
+		defer PutEncoder(enc)
+
+		data, _ := enc.Encode(pts)
+
+		d := GetDecoder(WithDecEncoding(Protobuf))
+		defer PutDecoder(d)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			d.Decode(data[0], WithPrecheck(false))
+		}
+	})
+
+	b.Run("decode-pb-with-easyproto", func(b *T.B) {
+		enc := GetEncoder(WithEncEncoding(Protobuf))
+		defer PutEncoder(enc)
+
+		data, _ := enc.Encode(pts)
+
+		d := GetDecoder(WithDecEncoding(Protobuf), WithDecEasyproto(true))
+		defer PutDecoder(d)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			d.Decode(data[0])
+		}
+	})
+
+	b.Run("decode-pb-with-easyproto-no-check", func(b *T.B) {
+		enc := GetEncoder(WithEncEncoding(Protobuf))
+		defer PutEncoder(enc)
+
+		data, _ := enc.Encode(pts)
+
+		d := GetDecoder(WithDecEncoding(Protobuf), WithDecEasyproto(true))
+		defer PutDecoder(d)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			d.Decode(data[0], WithPrecheck(false))
+		}
+	})
+
+	b.Run("decode-json", func(b *T.B) {
 		enc := GetEncoder(WithEncEncoding(JSON))
 		defer PutEncoder(enc)
 
@@ -548,6 +593,40 @@ func BenchmarkDecode(b *T.B) {
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
 			d.Decode(data[0])
+		}
+	})
+
+	b.Run("decode-json-no-check", func(b *T.B) {
+		enc := GetEncoder(WithEncEncoding(JSON))
+		defer PutEncoder(enc)
+
+		data, _ := enc.Encode(pts)
+
+		d := GetDecoder(WithDecEncoding(JSON))
+		defer PutDecoder(d)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			d.Decode(data[0], WithPrecheck(false))
+		}
+	})
+
+	b.Run("decode-pbjson-no-check", func(b *T.B) {
+		enc := GetEncoder(WithEncEncoding(JSON))
+		defer PutEncoder(enc)
+
+		for _, pt := range pts {
+			pt.SetFlag(Ppb)
+		}
+
+		data, _ := enc.Encode(pts)
+
+		d := GetDecoder(WithDecEncoding(JSON))
+		defer PutDecoder(d)
+
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			d.Decode(data[0], WithPrecheck(false))
 		}
 	})
 }

--- a/point/easyproto_test.go
+++ b/point/easyproto_test.go
@@ -95,14 +95,16 @@ func TestEasyproto(t *T.T) {
 		kvs = kvs.AddV2("tag-1", "value-1", true, WithKVTagSet(true))
 
 		pts := []*Point{
-			NewPointV2("p1", kvs),
+			NewPointV2("p1", kvs, WithTimestamp(123)),
 		}
 
 		var dst []byte
 
+		// marshalled with easyproto
 		dst = marshalPoints(pts, dst)
 
-		dec := GetDecoder(WithDecEncoding(Protobuf))
+		// unmarshal with gogo-proto
+		dec := GetDecoder(WithDecEncoding(Protobuf), WithDecEasyproto(false))
 		defer PutDecoder(dec)
 
 		pts2, err := dec.Decode(dst)
@@ -125,7 +127,7 @@ func TestEasyproto(t *T.T) {
 		kvs = kvs.AddV2("tag-1", "value-1", false, WithKVTagSet(true))
 
 		pts := []*Point{
-			NewPointV2("p1", kvs),
+			NewPointV2("p1", kvs, WithTimestamp(123)),
 		}
 		t.Logf("pt: %s", pts[0].Pretty())
 

--- a/point/rand_test.go
+++ b/point/rand_test.go
@@ -199,7 +199,13 @@ func TestWithFixKeys(t *T.T) {
 func BenchmarkRandWithPool(b *T.B) {
 	b.Run("with-pool-v3", func(b *T.B) {
 		pp := NewReservedCapPointPool(1000)
-		r := NewRander(WithRandPointPool(pp), WithFixedKeys(true), WithFixedTags(true), WithRandStringValues(false))
+		SetPointPool(pp)
+
+		b.Cleanup(func() {
+			ClearPointPool()
+		})
+
+		r := NewRander(WithFixedKeys(true), WithFixedTags(true), WithRandStringValues(false))
 
 		for i := 0; i < b.N; i++ {
 			pts := r.Rand(1000)
@@ -211,7 +217,12 @@ func BenchmarkRandWithPool(b *T.B) {
 
 	b.Run("with-reserved-pool", func(b *T.B) {
 		pp := NewReservedCapPointPool(128)
-		r := NewRander(WithRandPointPool(pp), WithFixedKeys(true), WithFixedTags(true), WithRandStringValues(false))
+		SetPointPool(pp)
+
+		b.Cleanup(func() {
+			ClearPointPool()
+		})
+		r := NewRander(WithFixedKeys(true), WithFixedTags(true), WithRandStringValues(false))
 
 		for i := 0; i < b.N; i++ {
 			pts := r.Rand(1000)


### PR DESCRIPTION
- easyproto not the dafault protobuf point decoder when point-pool enabled
- gogo-protobuf unmarshal make these points escaped from point-pool and released by GC
- fix bug in point rander that reset the global point-pool