### PR TITLE
Restricting network access to http_request functions

### DIFF
--- a/pipeline/ptinput/funcs/fn_http_request.go
+++ b/pipeline/ptinput/funcs/fn_http_request.go
@@ -29,11 +29,11 @@ var defaultTransport http.RoundTripper = &http.Transport{
 }
 
 var gDisableInternalHost bool
-var gCidrs []string
+var gCIDRs []string
 
 func SetNetFilter(disableInternal bool, cidrList []string) {
 	gDisableInternalHost = disableInternal
-	gCidrs = append(gCidrs, cidrList...)
+	gCIDRs = append(gCIDRs, cidrList...)
 }
 
 func filterHost(host string, disableInternal bool, cidrs []string) bool {
@@ -113,7 +113,7 @@ func HTTPRequest(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
 			funcExpr.Param[1].StartPos())
 	}
 
-	if filterURL(url.(string), gDisableInternalHost, gCidrs) {
+	if filterURL(url.(string), gDisableInternalHost, gCIDRs) {
 		ctx.Regs.ReturnAppend(nil, ast.Nil)
 		return nil
 	}

--- a/pipeline/ptinput/funcs/fn_http_request.go
+++ b/pipeline/ptinput/funcs/fn_http_request.go
@@ -28,12 +28,12 @@ var defaultTransport http.RoundTripper = &http.Transport{
 	ExpectContinueTimeout: 1 * time.Second,
 }
 
-var disableInternalHost bool
-var cidrs []string
+var gDisableInternalHost bool
+var gCidrs []string
 
 func SetNetFilter(disableInternal bool, cidrList []string) {
-	disableInternalHost = disableInternal
-	cidrs = append(cidrs, cidrList...)
+	gDisableInternalHost = disableInternal
+	gCidrs = append(gCidrs, cidrList...)
 }
 
 func filterHost(host string, disableInternal bool, cidrs []string) bool {
@@ -113,7 +113,7 @@ func HTTPRequest(ctx *runtime.Task, funcExpr *ast.CallExpr) *errchain.PlError {
 			funcExpr.Param[1].StartPos())
 	}
 
-	if filterURL(url.(string), disableInternalHost, cidrs) {
+	if filterURL(url.(string), gDisableInternalHost, gCidrs) {
 		ctx.Regs.ReturnAppend(nil, ast.Nil)
 		return nil
 	}


### PR DESCRIPTION
http_request 函数新增功能：

- 支持 cidr 和 host 白名单
- 支持禁止访问内部网络

两个白名单是或的关系

白名单的优先级高于禁止内部网络
