### PR TITLE
feat(dialtesting): preserve workspace language codes

### DIFF
--- a/dialtesting/task.go
+++ b/dialtesting/task.go
@@ -538,10 +538,22 @@ func (t *Task) GetHostName() ([]string, error) {
 }
 
 func (t *Task) GetWorkspaceLanguage() string {
-	if t.WorkspaceLanguage == "en" {
+	return NormalizeWorkspaceLanguage(t.WorkspaceLanguage)
+}
+
+func NormalizeWorkspaceLanguage(language string) string {
+	switch strings.ToLower(strings.ReplaceAll(strings.TrimSpace(language), "_", "-")) {
+	case "en":
 		return "en"
+	case "id":
+		return "id"
+	case "zh-hant", "zh-tw", "zh-hk":
+		return "zh-hant"
+	case "zh", "zh-cn", "zh-hans":
+		return "zh"
+	default:
+		return "zh"
 	}
-	return "zh"
 }
 
 func (t *Task) GetDFLabel() string {

--- a/dialtesting/task_test.go
+++ b/dialtesting/task_test.go
@@ -68,6 +68,31 @@ func TestCreateTaskChild(t *testing.T) {
 	assert.NotNil(t, task)
 }
 
+func TestNormalizeWorkspaceLanguage(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "default empty", in: "", want: "zh"},
+		{name: "unknown fallback", in: "go", want: "zh"},
+		{name: "zh", in: "zh", want: "zh"},
+		{name: "zh cn", in: "zh-CN", want: "zh"},
+		{name: "zh hans", in: "zh_Hans", want: "zh"},
+		{name: "en", in: "en", want: "en"},
+		{name: "id", in: "id", want: "id"},
+		{name: "zh hant", in: "zh-Hant", want: "zh-hant"},
+		{name: "zh tw", in: "zh_TW", want: "zh-hant"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, NormalizeWorkspaceLanguage(tc.in))
+			assert.Equal(t, tc.want, (&Task{WorkspaceLanguage: tc.in}).GetWorkspaceLanguage())
+		})
+	}
+}
+
 func TestCustomFunc(t *testing.T) {
 	ct := &HTTPTask{
 		URL: `{{date "iso8601"}}`,


### PR DESCRIPTION
## Summary

This PR fixes workspace language normalization for dialtesting tasks.

Previously, `GetWorkspaceLanguage()` only preserved `en`; every other value was forced to `zh`. This caused valid workspace language codes such as Indonesian and Traditional Chinese variants to be lost.

## Changes

- Add `NormalizeWorkspaceLanguage()` to centralize workspace language handling.
- Preserve supported language codes:
  - `en`
  - `id`
  - `zh-hant`
- Normalize common Chinese variants:
  - `zh-CN`, `zh-Hans` -> `zh`
  - `zh-Hant`, `zh-TW`, `zh-HK` -> `zh-hant`
- Normalize casing, surrounding spaces, and `_` separators.
- Keep existing fallback behavior: empty or unknown language values still resolve to `zh`.

